### PR TITLE
Refactor cpu.py and add new requirements

### DIFF
--- a/cpu.py
+++ b/cpu.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 import struct
 import glob
 import binascii
@@ -240,6 +241,8 @@ def step():
 
 
 if __name__ == "__main__":
+  if not os.path.isdir('test-cache'):
+    os.mkdir('test-cache')
   for x in glob.glob("riscv-tests/isa/rv32ui-p-*"):
     if x.endswith('.dump'):
       continue

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+numpy
 pyelftools==0.27
+tqdm


### PR DESCRIPTION
- Add `os.mkdir` in cpu.py so it runs without having to manually add test-cache
- Add numpy and tqdm to requirements.txt so we can run riskmem.py