### PR TITLE
Improve makefile

### DIFF
--- a/firmwares/Makefile
+++ b/firmwares/Makefile
@@ -1,6 +1,8 @@
 # This code is mostly taken from SERV project by Olof Kindgren
 # Please take a look at the project: https://github.com/olofk/serv
 
+all: $(patsubst %.S,%.elf,$(wildcard *.S))
+
 %.elf: %.S
 	riscv64-unknown-elf-gcc -nostartfiles -march=rv32i -mabi=ilp32 -Tlink.ld -DTEST_FUNC_NAME=$(notdir $(basename $<)) \
 		-DTEST_FUNC_TXT='"$(notdir $(basename $<))"' -DTEST_FUNC_RET=$(notdir $(basename $<))_ret $< -o $(notdir $(basename $<)).elf

--- a/firmwares/Makefile
+++ b/firmwares/Makefile
@@ -1,23 +1,25 @@
 # This code is mostly taken from SERV project by Olof Kindgren
 # Please take a look at the project: https://github.com/olofk/serv
 
+CROSS_COMPILE ?= riscv64-unknown-elf-
+
 all: $(patsubst %.S,%.elf,$(wildcard *.S))
 
 %.elf: %.S
-	riscv64-unknown-elf-gcc -nostartfiles -march=rv32i -mabi=ilp32 -Tlink.ld -DTEST_FUNC_NAME=$(notdir $(basename $<)) \
+	$(CROSS_COMPILE)gcc -nostartfiles -march=rv32i -mabi=ilp32 -Tlink.ld -DTEST_FUNC_NAME=$(notdir $(basename $<)) \
 		-DTEST_FUNC_TXT='"$(notdir $(basename $<))"' -DTEST_FUNC_RET=$(notdir $(basename $<))_ret $< -o $(notdir $(basename $<)).elf
 %.defs: %.S
-	riscv64-unknown-elf-gcc -E -nostartfiles -march=rv32i -mabi=ilp32 -Tlink.ld -DTEST_FUNC_NAME=$(notdir $(basename $<)) \
+	$(CROSS_COMPILE)gcc -E -nostartfiles -march=rv32i -mabi=ilp32 -Tlink.ld -DTEST_FUNC_NAME=$(notdir $(basename $<)) \
 		-DTEST_FUNC_TXT='"$(notdir $(basename $<))"' -DTEST_FUNC_RET=$(notdir $(basename $<))_ret $< > $(notdir $(basename $<)).i
 %.obj: %.elf
-	riscv64-unknown-elf-objdump -D $(notdir $(basename $<)).elf > $(notdir $(basename $<)).obj
+	$(CROSS_COMPILE)objdump -D $(notdir $(basename $<)).elf > $(notdir $(basename $<)).obj
 %.test: %.S
-	riscv64-unknown-elf-gcc -nostartfiles -march=rv32i -mabi=ilp32 -Tlink.ld -DTEST_FUNC_NAME=$(notdir $(basename $<)) \
+	$(CROSS_COMPILE)gcc -nostartfiles -march=rv32i -mabi=ilp32 -Tlink.ld -DTEST_FUNC_NAME=$(notdir $(basename $<)) \
 		-DTEST_FUNC_TXT='"$(notdir $(basename $<))"' -DTEST_FUNC_RET=$(notdir $(basename $<))_ret $< -o $(notdir $(basename $<)).elf
-	riscv64-unknown-elf-objdump -D $(notdir $(basename $<)).elf > $(notdir $(basename $<)).obj
+	$(CROSS_COMPILE)objdump -D $(notdir $(basename $<)).elf > $(notdir $(basename $<)).obj
 	python3 makehex.py $(notdir $(basename $<)).elf 2048 > $(notdir $(basename $<)).hex
 %.bin: %.elf
-	riscv64-unknown-elf-objcopy -O binary $< $@
+	$(CROSS_COMPILE)objcopy -O binary $< $@
 %.hex: %.bin
 	python3 makehex.py $< 4096 > $@
 clean:


### PR DESCRIPTION
- Added a `make all` target that builds all elf files (note that csr.S doesn't build, might want to remove it?)
- Added an overridable CROSS_COMPILE variable to choose which compiler to use (`riscv32-unknown-elf-` or `riscv64-unknown-elf-`, could also point somewhere that is not in the $PATH)
